### PR TITLE
Use generics in Vadi public API

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -10,11 +10,9 @@ vadi_micro_version = version_array[2].to_int ()
 
 vadi_api_version = '@0@.0'.format (vadi_major_version)
 vadi_api_name = '@0@-@1@'.format (meson.project_name (), vadi_api_version)
-vadi_gi_name = 'Vadi-@0@'.format (vadi_api_version)
 
 vadi_header = '@0@.h'.format (meson.project_name ())
 vadi_vapi = '@0@.vapi'.format (vadi_api_name)
-vadi_gir = '@0@.gir'.format (vadi_gi_name)
 vadi_pc = '@0@.pc'.format (vadi_api_name)
 vadi_deps = '@0@.deps'.format (vadi_api_name)
 
@@ -30,10 +28,9 @@ vadi = library (
 
      vala_header: vadi_header,
        vala_vapi: vadi_vapi,
-        vala_gir: vadi_gir,
     dependencies: deps,
          install: true,
-     install_dir: [true, true, true, true]
+     install_dir: [true, true, true]
 )
 
 vadi_dep = declare_dependency (

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -15,7 +15,6 @@ vadi_gi_name = 'Vadi-@0@'.format (vadi_api_version)
 vadi_header = '@0@.h'.format (meson.project_name ())
 vadi_vapi = '@0@.vapi'.format (vadi_api_name)
 vadi_gir = '@0@.gir'.format (vadi_gi_name)
-vadi_typelib = '@0@.typelib'.format (vadi_gi_name)
 vadi_pc = '@0@.pc'.format (vadi_api_name)
 vadi_deps = '@0@.deps'.format (vadi_api_name)
 
@@ -35,25 +34,6 @@ vadi = library (
     dependencies: deps,
          install: true,
      install_dir: [true, true, true, true]
-)
-
-g_ir_compiler = find_program ('g-ir-compiler')
-
-custom_target (
-    vadi_typelib,
-    command: [
-        g_ir_compiler,
-        '--shared-library',
-        vadi.full_path (),
-        '--output',
-        '@OUTPUT@',
-        meson.current_build_dir () / vadi_gir
-    ],
-
-         output: vadi_typelib,
-        depends: vadi,
-        install: true,
-    install_dir: get_option ('libdir') / 'girepository-1.0'
 )
 
 vadi_dep = declare_dependency (

--- a/lib/vadi-container.vala
+++ b/lib/vadi-container.vala
@@ -31,12 +31,12 @@ public class Vadi.Container : GLib.Object
 
     /* Public methods */
 
-    public void register_type (GLib.Type key_type, GLib.Type value_type)
-        requires (key_type.is_interface () || key_type.is_object ())
-        requires (value_type.is_object ())
-        requires (value_type.is_a (key_type))
+    public void register_type<K, V> ()
+        requires (typeof (K).is_interface () || typeof (K).is_object ())
+        requires (typeof (V).is_object ())
+        requires (typeof (V).is_a (typeof (K)))
     {
-        this._types[key_type] = value_type;
+        this._types[typeof (K)] = typeof (V);
     }
 
     public void register_factory<K> (ContainerFactoryFunc<K> container_factory)

--- a/lib/vadi-container.vala
+++ b/lib/vadi-container.vala
@@ -45,11 +45,11 @@ public class Vadi.Container : GLib.Object
         this._factories[typeof (K)] = container_factory;
     }
 
-    public void register_instance (GLib.Type key_type, GLib.Object instance)
-        requires (key_type.is_interface () || key_type.is_object ())
-        requires (instance.get_type ().is_a (key_type))
+    public void register_instance<K> (K instance)
+        requires (typeof (K).is_interface () || typeof (K).is_object ())
+        requires (instance is K)
     {
-        this._instances[key_type] = instance;
+        this._instances[typeof (K)] = (GLib.Object) instance;
     }
 
     public GLib.Object? resolve (GLib.Type type)

--- a/lib/vadi-container.vala
+++ b/lib/vadi-container.vala
@@ -16,7 +16,7 @@
  */
 
 [CCode (has_target = false)]
-public delegate GLib.Object Vadi.ContainerFactoryFunc (Container container);
+public delegate T Vadi.ContainerFactoryFunc<T> (Container container);
 
 public class Vadi.Container : GLib.Object
 {
@@ -39,10 +39,10 @@ public class Vadi.Container : GLib.Object
         this._types[key_type] = value_type;
     }
 
-    public void register_factory (GLib.Type key_type, ContainerFactoryFunc container_factory)
-        requires (key_type.is_interface () || key_type.is_object ())
+    public void register_factory<K> (ContainerFactoryFunc<K> container_factory)
+        requires (typeof (K).is_interface () || typeof (K).is_object ())
     {
-        this._factories[key_type] = container_factory;
+        this._factories[typeof (K)] = container_factory;
     }
 
     public void register_instance (GLib.Type key_type, GLib.Object instance)
@@ -61,7 +61,7 @@ public class Vadi.Container : GLib.Object
 
         if (this._factories.has_key (type)) {
             ContainerFactoryFunc factory = this._factories[type];
-            this._instances[type]        = factory (this);
+            this._instances[type]        = (GLib.Object) factory (this);
 
             return this._instances[type];
         }

--- a/lib/vadi-container.vala
+++ b/lib/vadi-container.vala
@@ -52,34 +52,10 @@ public class Vadi.Container : GLib.Object
         this._instances[typeof (K)] = (GLib.Object) instance;
     }
 
-    public GLib.Object? resolve (GLib.Type type)
-        requires (type.is_interface () || type.is_object ())
+    public T? resolve<T> ()
+        requires (typeof (T).is_interface () || typeof (T).is_object ())
     {
-        if (this._instances.has_key (type)) {
-            return this._instances[type];
-        }
-
-        if (this._factories.has_key (type)) {
-            ContainerFactoryFunc factory = this._factories[type];
-            this._instances[type]        = (GLib.Object) factory (this);
-
-            return this._instances[type];
-        }
-
-        GLib.Type resolve_type = this._types.has_key (type) ? this._types[type] : type;
-
-        if (resolve_type.is_object ()) {
-            (unowned GLib.ParamSpec)[] props = this.get_construct_properties (resolve_type);
-
-            (unowned string)[] names = this.get_matched_property_names (props);
-            GLib.Value[] values      = this.get_matched_property_values (props);
-
-            this._instances[type] = GLib.Object.new_with_properties (resolve_type, names, values);
-
-            return this._instances[type];
-        }
-
-        return null;
+        return this.resolve_type (typeof (T));
     }
 
     /* End public methods */
@@ -146,7 +122,7 @@ public class Vadi.Container : GLib.Object
                     values.resize (values.length + 1);
 
                     var @value = GLib.Value (key_type);
-                    @value.set_object (this.resolve (key_type));
+                    @value.set_object (this.resolve_type (key_type));
 
                     values[values.length - 1] = @value;
                 }
@@ -157,7 +133,7 @@ public class Vadi.Container : GLib.Object
                     values.resize (values.length + 1);
 
                     var @value = GLib.Value (key_type);
-                    @value.set_object (this.resolve (key_type));
+                    @value.set_object (this.resolve_type (key_type));
 
                     values[values.length - 1] = @value;
                 }
@@ -168,7 +144,7 @@ public class Vadi.Container : GLib.Object
                     values.resize (values.length + 1);
 
                     var @value = GLib.Value (key_type);
-                    @value.set_object (this.resolve (key_type));
+                    @value.set_object (this.resolve_type (key_type));
 
                     values[values.length - 1] = @value;
                 }
@@ -176,6 +152,35 @@ public class Vadi.Container : GLib.Object
         }
 
         return values;
+    }
+
+    private GLib.Object? resolve_type (GLib.Type type)
+    {
+        if (this._instances.has_key (type)) {
+            return this._instances[type];
+        }
+
+        if (this._factories.has_key (type)) {
+            ContainerFactoryFunc factory = this._factories[type];
+            this._instances[type]        = (GLib.Object) factory (this);
+
+            return this._instances[type];
+        }
+
+        GLib.Type resolve_type = this._types.has_key (type) ? this._types[type] : type;
+
+        if (resolve_type.is_object ()) {
+            (unowned GLib.ParamSpec)[] props = this.get_construct_properties (resolve_type);
+
+            (unowned string)[] names = this.get_matched_property_names (props);
+            GLib.Value[] values      = this.get_matched_property_values (props);
+
+            this._instances[type] = GLib.Object.new_with_properties (resolve_type, names, values);
+
+            return this._instances[type];
+        }
+
+        return null;
     }
 
     /* End private methods */

--- a/tests/test-container.vala
+++ b/tests/test-container.vala
@@ -44,10 +44,10 @@ int main (string[] args)
 {
     GLib.Test.init (ref args);
 
-    GLib.Test.add_func ("/vadi/container/resolve/iface", () => {
+    GLib.Test.add_func ("/vadi/container/resolve/interface", () => {
         var container = new Vadi.Container ();
 
-        GLib.Object service = container.resolve (typeof (Service));
+        Service service = container.resolve<Service> ();
 
         GLib.assert_null (service);
     });
@@ -55,10 +55,9 @@ int main (string[] args)
     GLib.Test.add_func ("/vadi/container/register/none", () => {
         var container = new Vadi.Container ();
 
-        GLib.Object service = container.resolve (typeof (FoodService));
+        FoodService service = container.resolve<FoodService> ();
 
         GLib.assert_nonnull (service);
-        GLib.assert_true (service.get_type ().is_a (typeof (FoodService)));
     });
 
     GLib.Test.add_func ("/vadi/container/register/type/simple", () => {
@@ -66,10 +65,10 @@ int main (string[] args)
 
         container.register_type<Service, FoodService> ();
 
-        GLib.Object service = container.resolve (typeof (Service));
+        Service? service = container.resolve<Service> ();
 
         GLib.assert_nonnull (service);
-        GLib.assert_true (service.get_type ().is_a (typeof (FoodService)));
+        GLib.assert_true (service is FoodService);
     });
 
     GLib.Test.add_func ("/vadi/container/register/type/simple-repeat", () => {
@@ -77,13 +76,13 @@ int main (string[] args)
 
         container.register_type<Service, FoodService> ();
 
-        GLib.Object service_a = container.resolve (typeof (Service));
-        GLib.Object service_b = container.resolve (typeof (Service));
+        Service service_a = container.resolve<Service> ();
+        Service service_b = container.resolve<Service> ();
 
         GLib.assert_nonnull (service_a);
         GLib.assert_nonnull (service_b);
-        GLib.assert_true (service_a.get_type ().is_a (typeof (FoodService)));
-        GLib.assert_true (service_b.get_type ().is_a (typeof (FoodService)));
+        GLib.assert_true (service_a is FoodService);
+        GLib.assert_true (service_b is FoodService);
 
         GLib.assert_true (service_a == service_b);
     });
@@ -93,11 +92,11 @@ int main (string[] args)
 
         container.register_type<Service, FoodService> ();
 
-        GLib.Object client = container.resolve (typeof (Client));
+        Client client = container.resolve<Client> ();
 
         GLib.assert_nonnull (client);
-        GLib.assert_nonnull (((Client) client).service);
-        GLib.assert_true (((Client) client).service.get_type ().is_a (typeof (FoodService)));
+        GLib.assert_nonnull (client.service);
+        GLib.assert_true (client.service is FoodService);
     });
 
     GLib.Test.add_func ("/vadi/container/register/type/register-myself", () => {
@@ -106,11 +105,11 @@ int main (string[] args)
         container.register_type<Service, FoodService> ();
         container.register_type<Client, Client> ();
 
-        GLib.Object client = container.resolve (typeof (Client));
+        Client client = container.resolve<Client> ();
 
         GLib.assert_nonnull (client);
-        GLib.assert_nonnull (((Client) client).service);
-        GLib.assert_true (((Client) client).service.get_type ().is_a (typeof (FoodService)));
+        GLib.assert_nonnull (client.service);
+        GLib.assert_true (client.service is FoodService);
     });
 
     GLib.Test.add_func ("/vadi/container/register/factory/simple", () => {
@@ -120,10 +119,10 @@ int main (string[] args)
             return new FoodService ();
         });
 
-        GLib.Object service = (Service) container.resolve (typeof (Service));
+        Service service = container.resolve<Service> ();
 
         GLib.assert_nonnull (service);
-        GLib.assert_true (service.get_type ().is_a (typeof (FoodService)));
+        GLib.assert_true (service is FoodService);
     });
 
     GLib.Test.add_func ("/vadi/container/register/factory/recursive", () => {
@@ -133,14 +132,14 @@ int main (string[] args)
             return new FoodService ();
         });
         container.register_factory<Client> (container => {
-            return new Client ((Service) container.resolve (typeof (Service)));
+            return new Client (container.resolve<Service> ());
         });
 
-        GLib.Object client = container.resolve (typeof (Client));
+        Client client = container.resolve<Client> ();
 
         GLib.assert_nonnull (client);
-        GLib.assert_nonnull (((Client) client).service);
-        GLib.assert_true (((Client) client).service.get_type ().is_a (typeof (FoodService)));
+        GLib.assert_nonnull (client.service);
+        GLib.assert_true (client.service is FoodService);
     });
 
     GLib.Test.add_func ("/vadi/container/register/instance/simple", () => {
@@ -149,7 +148,7 @@ int main (string[] args)
 
         container.register_instance<Service> (food_service);
 
-        GLib.Object service = container.resolve (typeof (Service));
+        Service service = container.resolve<Service> ();
 
         GLib.assert_nonnull (service);
         GLib.assert_true (service == food_service);
@@ -160,14 +159,14 @@ int main (string[] args)
 
         container.register_type<Service, FoodService> ();
         container.register_factory<Client> (container => {
-            return new Client ((Service) container.resolve (typeof (Service)));
+            return new Client (container.resolve<Service> ());
         });
 
-        GLib.Object client = container.resolve (typeof (Client));
+        Client client = container.resolve<Client> ();
 
         GLib.assert_nonnull (client);
-        GLib.assert_nonnull (((Client) client).service);
-        GLib.assert_true (((Client) client).service.get_type ().is_a (typeof (FoodService)));
+        GLib.assert_nonnull (client.service);
+        GLib.assert_true (client.service is FoodService);
     });
 
     GLib.Test.add_func ("/vadi/container/register/mixed/factory-type", () => {
@@ -177,11 +176,11 @@ int main (string[] args)
             return new FoodService ();
         });
 
-        GLib.Object client = container.resolve (typeof (Client));
+        Client client = container.resolve<Client> ();
 
         GLib.assert_nonnull (client);
-        GLib.assert_nonnull (((Client) client).service);
-        GLib.assert_true (((Client) client).service.get_type ().is_a (typeof (FoodService)));
+        GLib.assert_nonnull (client.service);
+        GLib.assert_true (client.service is FoodService);
     });
 
     GLib.Test.add_func ("/vadi/container/register/mixed/instance-type", () => {
@@ -190,11 +189,11 @@ int main (string[] args)
 
         container.register_instance<Service> (food_service);
 
-        GLib.Object client = container.resolve (typeof (Client));
+        Client client = container.resolve<Client> ();
 
         GLib.assert_nonnull (client);
-        GLib.assert_nonnull (((Client) client).service);
-        GLib.assert_true (((Client) client).service == food_service);
+        GLib.assert_nonnull (client.service);
+        GLib.assert_true (client.service == food_service);
     });
 
     GLib.Test.add_func ("/vadi/container/register/mixed/instance-factory", () => {
@@ -203,14 +202,14 @@ int main (string[] args)
 
         container.register_instance<Service> (food_service);
         container.register_factory<Client> (container => {
-            return new Client ((Service) container.resolve (typeof (Service)));
+            return new Client (container.resolve<Service> ());
         });
 
-        GLib.Object client = container.resolve (typeof (Client));
+        Client client = container.resolve<Client> ();
 
         GLib.assert_nonnull (client);
-        GLib.assert_nonnull (((Client) client).service);
-        GLib.assert_true (((Client) client).service == food_service);
+        GLib.assert_nonnull (client.service);
+        GLib.assert_true (client.service == food_service);
     });
 
     return GLib.Test.run ();

--- a/tests/test-container.vala
+++ b/tests/test-container.vala
@@ -116,7 +116,7 @@ int main (string[] args)
     GLib.Test.add_func ("/vadi/container/register/factory/simple", () => {
         var container = new Vadi.Container ();
 
-        container.register_factory (typeof (Service), container => {
+        container.register_factory<Service> (container => {
             return new FoodService ();
         });
 
@@ -129,10 +129,10 @@ int main (string[] args)
     GLib.Test.add_func ("/vadi/container/register/factory/recursive", () => {
         var container = new Vadi.Container ();
 
-        container.register_factory (typeof (Service), container => {
+        container.register_factory<Service> (container => {
             return new FoodService ();
         });
-        container.register_factory (typeof (Client), container => {
+        container.register_factory<Client> (container => {
             return new Client ((Service) container.resolve (typeof (Service)));
         });
 
@@ -159,7 +159,7 @@ int main (string[] args)
         var container = new Vadi.Container ();
 
         container.register_type (typeof (Service), typeof (FoodService));
-        container.register_factory (typeof (Client), container => {
+        container.register_factory<Client> (container => {
             return new Client ((Service) container.resolve (typeof (Service)));
         });
 
@@ -173,7 +173,7 @@ int main (string[] args)
     GLib.Test.add_func ("/vadi/container/register/mixed/factory-type", () => {
         var container = new Vadi.Container ();
 
-        container.register_factory (typeof (Service), container => {
+        container.register_factory<Service> (container => {
             return new FoodService ();
         });
 
@@ -202,7 +202,7 @@ int main (string[] args)
         var food_service = new FoodService ();
 
         container.register_instance (typeof (Service), food_service);
-        container.register_factory (typeof (Client), container => {
+        container.register_factory<Client> (container => {
             return new Client ((Service) container.resolve (typeof (Service)));
         });
 

--- a/tests/test-container.vala
+++ b/tests/test-container.vala
@@ -47,7 +47,7 @@ int main (string[] args)
     GLib.Test.add_func ("/vadi/container/resolve/interface", () => {
         var container = new Vadi.Container ();
 
-        Service service = container.resolve<Service> ();
+        Service? service = container.resolve<Service> ();
 
         GLib.assert_null (service);
     });
@@ -55,7 +55,7 @@ int main (string[] args)
     GLib.Test.add_func ("/vadi/container/register/none", () => {
         var container = new Vadi.Container ();
 
-        FoodService service = container.resolve<FoodService> ();
+        FoodService? service = container.resolve<FoodService> ();
 
         GLib.assert_nonnull (service);
     });
@@ -76,8 +76,8 @@ int main (string[] args)
 
         container.register_type<Service, FoodService> ();
 
-        Service service_a = container.resolve<Service> ();
-        Service service_b = container.resolve<Service> ();
+        Service? service_a = container.resolve<Service> ();
+        Service? service_b = container.resolve<Service> ();
 
         GLib.assert_nonnull (service_a);
         GLib.assert_nonnull (service_b);
@@ -92,7 +92,7 @@ int main (string[] args)
 
         container.register_type<Service, FoodService> ();
 
-        Client client = container.resolve<Client> ();
+        Client? client = container.resolve<Client> ();
 
         GLib.assert_nonnull (client);
         GLib.assert_nonnull (client.service);
@@ -105,7 +105,7 @@ int main (string[] args)
         container.register_type<Service, FoodService> ();
         container.register_type<Client, Client> ();
 
-        Client client = container.resolve<Client> ();
+        Client? client = container.resolve<Client> ();
 
         GLib.assert_nonnull (client);
         GLib.assert_nonnull (client.service);
@@ -119,7 +119,7 @@ int main (string[] args)
             return new FoodService ();
         });
 
-        Service service = container.resolve<Service> ();
+        Service? service = container.resolve<Service> ();
 
         GLib.assert_nonnull (service);
         GLib.assert_true (service is FoodService);
@@ -135,7 +135,7 @@ int main (string[] args)
             return new Client (container.resolve<Service> ());
         });
 
-        Client client = container.resolve<Client> ();
+        Client? client = container.resolve<Client> ();
 
         GLib.assert_nonnull (client);
         GLib.assert_nonnull (client.service);
@@ -148,7 +148,7 @@ int main (string[] args)
 
         container.register_instance<Service> (food_service);
 
-        Service service = container.resolve<Service> ();
+        Service? service = container.resolve<Service> ();
 
         GLib.assert_nonnull (service);
         GLib.assert_true (service == food_service);
@@ -162,7 +162,7 @@ int main (string[] args)
             return new Client (container.resolve<Service> ());
         });
 
-        Client client = container.resolve<Client> ();
+        Client? client = container.resolve<Client> ();
 
         GLib.assert_nonnull (client);
         GLib.assert_nonnull (client.service);
@@ -176,7 +176,7 @@ int main (string[] args)
             return new FoodService ();
         });
 
-        Client client = container.resolve<Client> ();
+        Client? client = container.resolve<Client> ();
 
         GLib.assert_nonnull (client);
         GLib.assert_nonnull (client.service);
@@ -189,7 +189,7 @@ int main (string[] args)
 
         container.register_instance<Service> (food_service);
 
-        Client client = container.resolve<Client> ();
+        Client? client = container.resolve<Client> ();
 
         GLib.assert_nonnull (client);
         GLib.assert_nonnull (client.service);
@@ -205,7 +205,7 @@ int main (string[] args)
             return new Client (container.resolve<Service> ());
         });
 
-        Client client = container.resolve<Client> ();
+        Client? client = container.resolve<Client> ();
 
         GLib.assert_nonnull (client);
         GLib.assert_nonnull (client.service);

--- a/tests/test-container.vala
+++ b/tests/test-container.vala
@@ -64,7 +64,7 @@ int main (string[] args)
     GLib.Test.add_func ("/vadi/container/register/type/simple", () => {
         var container = new Vadi.Container ();
 
-        container.register_type (typeof (Service), typeof (FoodService));
+        container.register_type<Service, FoodService> ();
 
         GLib.Object service = container.resolve (typeof (Service));
 
@@ -75,7 +75,7 @@ int main (string[] args)
     GLib.Test.add_func ("/vadi/container/register/type/simple-repeat", () => {
         var container = new Vadi.Container ();
 
-        container.register_type (typeof (Service), typeof (FoodService));
+        container.register_type<Service, FoodService> ();
 
         GLib.Object service_a = container.resolve (typeof (Service));
         GLib.Object service_b = container.resolve (typeof (Service));
@@ -91,7 +91,7 @@ int main (string[] args)
     GLib.Test.add_func ("/vadi/container/register/type/recursive", () => {
         var container = new Vadi.Container ();
 
-        container.register_type (typeof (Service), typeof (FoodService));
+        container.register_type<Service, FoodService> ();
 
         GLib.Object client = container.resolve (typeof (Client));
 
@@ -103,8 +103,8 @@ int main (string[] args)
     GLib.Test.add_func ("/vadi/container/register/type/register-myself", () => {
         var container = new Vadi.Container ();
 
-        container.register_type (typeof (Service), typeof (FoodService));
-        container.register_type (typeof (Client), typeof (Client));
+        container.register_type<Service, FoodService> ();
+        container.register_type<Client, Client> ();
 
         GLib.Object client = container.resolve (typeof (Client));
 
@@ -158,7 +158,7 @@ int main (string[] args)
     GLib.Test.add_func ("/vadi/container/register/mixed/type-factory", () => {
         var container = new Vadi.Container ();
 
-        container.register_type (typeof (Service), typeof (FoodService));
+        container.register_type<Service, FoodService> ();
         container.register_factory<Client> (container => {
             return new Client ((Service) container.resolve (typeof (Service)));
         });

--- a/tests/test-container.vala
+++ b/tests/test-container.vala
@@ -147,7 +147,7 @@ int main (string[] args)
         var container = new Vadi.Container ();
         var food_service = new FoodService ();
 
-        container.register_instance (typeof (Service), food_service);
+        container.register_instance<Service> (food_service);
 
         GLib.Object service = container.resolve (typeof (Service));
 
@@ -188,7 +188,7 @@ int main (string[] args)
         var container = new Vadi.Container ();
         var food_service = new FoodService ();
 
-        container.register_instance (typeof (Service), food_service);
+        container.register_instance<Service> (food_service);
 
         GLib.Object client = container.resolve (typeof (Client));
 
@@ -201,7 +201,7 @@ int main (string[] args)
         var container = new Vadi.Container ();
         var food_service = new FoodService ();
 
-        container.register_instance (typeof (Service), food_service);
+        container.register_instance<Service> (food_service);
         container.register_factory<Client> (container => {
             return new Client ((Service) container.resolve (typeof (Service)));
         });


### PR DESCRIPTION
Vadi currently has an API that tries to be friendly to C developers and GIR-based languages, which causes Vala developers to have a bit of an awkward syntax.

After consulting, it makes sense to make the public API only focus on providing a good experience for Vala developers, since GIR-based languages will have their own solutions for IoC, while C developers do not make use of advanced OOP techniques (like dependency injection).

Task list:
- [x] Update the public API to make use of generics
- [x] Update unit tests against the new API
- [x] Stop generating GIR files
- [x] Stop generating typelib files

Fixes #2 