### PR TITLE
VadiContainer: Fixed not being able to use local variables within the factory

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -1,4 +1,5 @@
 sources = files (
+    'vadi-container-factory-func-closure.vala',
     'vadi-container.vala'
 )
 

--- a/lib/vadi-container-factory-func-closure.vala
+++ b/lib/vadi-container-factory-func-closure.vala
@@ -1,0 +1,32 @@
+/* Vadi - An IoC Container for Vala
+ * Copyright (C) 2020 Nahuel Gomez Castro <nahual_gomca@outlook.com.ar>
+ *
+ * Vadi is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Vadi is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+public delegate T Vadi.ContainerFactoryFunc<T> (Vadi.Container container);
+
+// This is highly inspired on libgee's internal reimplementation of GClosure
+// https://gitlab.gnome.org/GNOME/libgee/-/blob/master/gee/functions.vala
+[CCode (simple_generics = true)]
+private class Vadi.ContainerFactoryFuncClosure<T> : GLib.Object
+{
+    public ContainerFactoryFunc<T> func;
+
+
+    public ContainerFactoryFuncClosure(owned ContainerFactoryFunc<T> func)
+    {
+        this.func = (owned) func;
+    }
+}

--- a/lib/vadi-container.vala
+++ b/lib/vadi-container.vala
@@ -15,9 +15,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-[CCode (has_target = false)]
-public delegate T Vadi.ContainerFactoryFunc<T> (Container container);
-
 public class Vadi.Container : GLib.Object
 {
     /* Private fields */

--- a/lib/vadi-container.vala
+++ b/lib/vadi-container.vala
@@ -19,9 +19,9 @@ public class Vadi.Container : GLib.Object
 {
     /* Private fields */
 
-    private Gee.Map<GLib.Type, GLib.Type>            _types;
-    private Gee.Map<GLib.Type, ContainerFactoryFunc> _factories;
-    private Gee.Map<GLib.Type, GLib.Object>          _instances;
+    private Gee.Map<GLib.Type, GLib.Type>                   _types;
+    private Gee.Map<GLib.Type, ContainerFactoryFuncClosure> _factories;
+    private Gee.Map<GLib.Type, GLib.Object>                 _instances;
 
     /* End private fields */
 
@@ -36,10 +36,10 @@ public class Vadi.Container : GLib.Object
         this._types[typeof (K)] = typeof (V);
     }
 
-    public void register_factory<K> (ContainerFactoryFunc<K> container_factory)
+    public void register_factory<K> (owned ContainerFactoryFunc<K> container_factory)
         requires (typeof (K).is_interface () || typeof (K).is_object ())
     {
-        this._factories[typeof (K)] = container_factory;
+        this._factories[typeof (K)] = new ContainerFactoryFuncClosure<K> ((owned) container_factory);
     }
 
     public void register_instance<K> (K instance)
@@ -158,8 +158,7 @@ public class Vadi.Container : GLib.Object
         }
 
         if (this._factories.has_key (type)) {
-            ContainerFactoryFunc factory = this._factories[type];
-            this._instances[type]        = (GLib.Object) factory (this);
+            this._instances[type] = (GLib.Object) this._factories[type].func (this);
 
             return this._instances[type];
         }
@@ -188,7 +187,7 @@ public class Vadi.Container : GLib.Object
     construct
     {
         this._types     = new Gee.HashMap<GLib.Type, GLib.Type> ();
-        this._factories = new Gee.HashMap<GLib.Type, ContainerFactoryFunc> ();
+        this._factories = new Gee.HashMap<GLib.Type, ContainerFactoryFuncClosure> ();
         this._instances = new Gee.HashMap<GLib.Type, GLib.Object> ();
     }
 

--- a/tests/test-container.vala
+++ b/tests/test-container.vala
@@ -142,6 +142,21 @@ int main (string[] args)
         GLib.assert_true (client.service is FoodService);
     });
 
+    GLib.Test.add_func ("/vadi/container/register/factory/use-local-variables", () => {
+        var container = new Vadi.Container ();
+        var food_service = new FoodService ();
+
+        container.register_factory<Client> (container => {
+            return new Client (food_service);
+        });
+
+        Client? client = container.resolve<Client> ();
+
+        GLib.assert_nonnull (client);
+        GLib.assert_nonnull (client.service);
+        GLib.assert_true (client.service == food_service);
+    });
+
     GLib.Test.add_func ("/vadi/container/register/instance/simple", () => {
         var container = new Vadi.Container ();
         var food_service = new FoodService ();


### PR DESCRIPTION
Support for using local variables within a factory has been added. For this, the way factories are stored inside the container was changed: Now a reimplementation of GClosure is used, taking inspiration from the work done in libgee

Tests were added to verify that this behavior continues to be maintained over time