### PR TITLE
feat: added nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1663578619,
+        "narHash": "sha256-kNgJXZIr4pi2NbDUfjj4APa+LlCmRUM4Ly2Xf70PVaw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a13d59408da1108fc6c9ffe4750ab7a33c581d24",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = "An IoC Container for Vala";
+
+  outputs = { self, nixpkgs, ... }:
+    let
+      supportedSystems = [
+        "aarch64-linux"
+        "i686-linux"
+        "riscv64-linux"
+        "x86_64-linux"
+        "x86_64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          default = pkgs.stdenv.mkDerivation rec {
+            name = "vadi";
+            src = self;
+            outputs = [ "out" "dev" ];
+
+            enableParallelBuilding = true;
+            nativeBuildInputs = with pkgs; [ meson ninja pkg-config vala gobject-introspection ];
+            buildInputs = with pkgs; [ glib libgee ];
+
+            meta = with pkgs.lib; {
+              homepage = "https://github.com/nahuelwexd/Vadi";
+              license = with licenses; [ lgpl3Only ];
+              maintainers = [ "Tristan Ross" "Nahu" ];
+            };
+          };
+        });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              meson
+              ninja
+              pkg-config
+              vala
+              glib
+							libgee
+							gobject-introspection
+            ];
+          };
+        });
+    };
+}


### PR DESCRIPTION
This adds a nix Flake which allows for developers using nix to use packages easily without having to technically install it. You can build the resulting package with `nix build` and enter a development shell with `nix develop`. However, it depends on nix being set up with Flake support.